### PR TITLE
Fix homepage description rendering when config description is empty

### DIFF
--- a/personal_website/themes/fengye/layout/index.ejs
+++ b/personal_website/themes/fengye/layout/index.ejs
@@ -51,13 +51,16 @@
         </div>
       </div>
       <!-- Description from config -->
+      <% const siteDescription = (config.description || '').toString(); %>
+      <% if (siteDescription.trim().length > 0) { %>
       <div class="description-container max-w-prose mx-auto grid grid-cols-1">
         <div class="text-left p-8">
           <p>
-            <%- config.description.replace(/(?:\r\n|\r|\n)/g, '<br>' ) %>
+            <%- siteDescription.replace(/(?:\r\n|\r|\n)/g, '<br>') %>
           </p>
         </div>
       </div>
+      <% } %>
       <!-- get content from index.md -->
       <div class="post-content mt-4">
       </div>


### PR DESCRIPTION
## Summary
- guard the homepage description block in the Fengye theme so it skips rendering when `config.description` is empty
- avoid calling `replace` on a null value to ensure the homepage builds successfully

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68db726a2ff8832e8f5532279bdcff43